### PR TITLE
added additional unit-test, cleaned up spacing

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/org/xmlpull/mxp1_serializer/MXSerializer.java
+++ b/brut.apktool/apktool-lib/src/main/java/org/xmlpull/mxp1_serializer/MXSerializer.java
@@ -10,7 +10,7 @@ import org.xmlpull.v1.XmlSerializer;
 /**
  * Implementation of XmlSerializer interface from XmlPull V1 API. This
  * implementation is optimzied for performance and low memory footprint.
- * 
+ *
  * <p>
  * Implemented features:
  * <ul>
@@ -25,7 +25,7 @@ import org.xmlpull.v1.XmlSerializer;
  * <li>PROPERTY_SERIALIZER_INDENTATION
  * <li>PROPERTY_SERIALIZER_LINE_SEPARATOR
  * </ul>
- * 
+ *
  */
 public class MXSerializer implements XmlSerializer {
 	protected final static String XML_URI = "http://www.w3.org/XML/1998/namespace";
@@ -1009,12 +1009,12 @@ public class MXSerializer implements XmlSerializer {
 				}
 			} else {
 				if (ch == '&') {
-                    if(!(i < text.length() - 3 && text.charAt(i+1) == 'l' 
-                            && text.charAt(i+2) == 't' && text.charAt(i+3) == ';')){
-                        if (i > pos)
-                            out.write(text.substring(pos, i));
-                        out.write("&amp;");
-                        pos = i + 1;
+					if (!(i < text.length() - 3 && text.charAt(i+1) == 'l'
+					    && text.charAt(i+2) == 't' && text.charAt(i+3) == ';')) {
+					    if (i > pos)
+					        out.write(text.substring(pos, i));
+					    out.write("&amp;");
+					    pos = i + 1;
                     }
 				} else if (ch == '<') {
 					if (i > pos)

--- a/brut.apktool/apktool-lib/src/test/resources/brut/apktool/testapp/res/values-mcc001/plurals.xml
+++ b/brut.apktool/apktool-lib/src/test/resources/brut/apktool/testapp/res/values-mcc001/plurals.xml
@@ -16,7 +16,8 @@
         <item quantity="other">foo %d</item>
         <item quantity="one">foo 1</item>
     </plurals>
-    <plurals name="issue658">
-        <item quantity="one">&lt;b>%d&lt;/b> guide123</item>
+    <plurals name="issue_658">
+        <item quantity="other">&lt;b>%d&lt;/b> guide123</item>
+        <item quantity="one">&lt;b>%d&lt;/b> 1</item>
     </plurals>
 </resources>


### PR DESCRIPTION
I just added an additional unit-test for the `one` property and fixed up some spacing issues. (Which weren't your fault).

I never implemented the tab spacing in `MXSerializer` since I didn't write it.
